### PR TITLE
Adding initial support for container indicator in tabs

### DIFF
--- a/theme/function-containers-indicator.css
+++ b/theme/function-containers-indicator.css
@@ -1,0 +1,40 @@
+/* Multiple style, change these to test it out */
+/* Uncomment the one you wanna use */
+
+/* Needs to be added to avoid overflowing, needs testing if this doesn't break anything */
+.tabbrowser-tab .tab-background {
+    overflow: clip;
+}
+
+/* Style 1 */
+/* Simply changing border to the left side of tab icon */
+
+/* .tabbrowser-tab .tab-context-line {
+  width: 3px;
+  height: 35px !important;
+  margin: 0 !important;
+} */
+
+/* Style 2 */
+/* Border around full tab */
+
+.tabbrowser-tab .tab-context-line {
+  border: 2px solid var(--identity-icon-color);
+  margin: 0 !important;
+  width: 100%;
+  height: 100% !important;
+  background: transparent !important;
+  border-radius: var(--tab-border-radius) !important;
+  opacity: 0.6;
+}
+
+/* Style 3 */
+/* Full color overlay */
+/* Will needs tweaks as text color could be unreadable in some combinations */
+
+/* .tabbrowser-tab .tab-context-line {
+  width: 100%;
+  height: 100% !important;
+  margin: 0 !important;
+  opacity: 0.7;
+} */

--- a/theme/function-containers-indicator.css
+++ b/theme/function-containers-indicator.css
@@ -9,16 +9,16 @@
 /* Style 1 */
 /* Simply changing border to the left side of tab icon */
 
-/* .tabbrowser-tab .tab-context-line {
+.tabbrowser-tab .tab-context-line {
   width: 3px;
   height: 35px !important;
   margin: 0 !important;
-} */
+}
 
 /* Style 2 */
 /* Border around full tab */
 
-.tabbrowser-tab .tab-context-line {
+/* .tabbrowser-tab .tab-context-line {
   border: 2px solid var(--identity-icon-color);
   margin: 0 !important;
   width: 100%;
@@ -26,7 +26,7 @@
   background: transparent !important;
   border-radius: var(--tab-border-radius) !important;
   opacity: 0.6;
-}
+} */
 
 /* Style 3 */
 /* Full color overlay */

--- a/userChrome.css
+++ b/userChrome.css
@@ -30,6 +30,7 @@ Tabs Size: (XS = 40px) (S = 140px) (L = 250px)
 
 @import url(theme/function-mini-button-bar.css);
 @import url(theme/function-tabs-collapse.css);
+@import url(theme/function-containers-indicator.css);
 @import url(theme/function-menu-button.css);
 @import url(theme/function-privatemode-indicator.css); /* sourced from MOG */
 @import url(theme/function-urlbar.css);


### PR DESCRIPTION
You can change style in `function-containers-indicator.css` file by uncommenting a specific style, and commenting the rest. Style 2 will need to be tweaked to be more in line with the rest of the theme.