### PR TITLE
fix: kde window controls w/ compact ui

### DIFF
--- a/theme/override-linux.css
+++ b/theme/override-linux.css
@@ -60,9 +60,14 @@ KDE compat. for themed Window decoration buttons
 @media (-moz-bool-pref: "ultima.OS.kde") {
 @media (-moz-platform: linux), (-moz-os-version: linux) {
 
-    :root[tabsintitlebar] .titlebar-buttonbox {
-        top: 7px !important;
-        right: 5px !important;
+    :root[tabsintitlebar] {
+        .titlebar-buttonbox {
+            top: 7px !important;
+            right: 5px !important;
+        }
+        &[uidensity="compact"] .titlebar-buttonbox {
+            top: 4px !important;
+        }
     }
     
     .titlebar-button, .titlebar-button[lwtheme="true"] {


### PR DESCRIPTION
Ensures the window controls are still centered horizontally when uidensity="compact".
![image](https://github.com/soulhotel/FF-ULTIMA/assets/153149335/ede5cfce-d565-43fb-a95d-e41d0c0f45d6)
![image](https://github.com/soulhotel/FF-ULTIMA/assets/153149335/c2f8f16a-49d4-4c57-99a1-e375595c7bf7)