### PR TITLE
Autohide Sidebery

### DIFF
--- a/doc/sidebery-alt-dark.css
+++ b/doc/sidebery-alt-dark.css
@@ -1,0 +1,177 @@
+#root {
+    /* Tab and PinnedTab height adjustment */
+    --tabs-height: 33px;
+    --tabs-pinned-height: var(--tabs-height);
+    --tabs-pinned-width: var(--tabs-height);
+
+    /* Theme */
+    --bg: #1a1b26 !important;
+    --tabs-fg: #d4d4d4 !important;
+    --tabs-bg-hover: #3b3948 !important;
+    --tabs-activated-bg: #5b5b66 !important;
+    --nav-btn-activated-bg: #1f222f !important;
+    --panel-btn: #f2f2f2 !important;
+    --warn: #8c4351 !important;
+    --search-icon-width: 38px;
+}
+
+#root .Tab {
+    --tabs-indent: 7px;
+}
+
+/* TABS */
+
+.Tab .lvl-wrapper:after {
+    display: none;
+}
+
+.Tab {
+    margin: auto;
+    width: 100%;
+    border-radius: 3px;
+}
+
+.Tab .close>svg:hover {
+    /* Styling the tab close button */
+    border-radius: 3px;
+    background: var(--warn) !important;
+    opacity: 80%;
+}
+
+.Tab .title {
+    overflow: hidden !important;
+}
+
+/* PINNED TABS */
+
+.PinnedTabsBar {
+    padding-top: 2px !important;
+    background-color: var(--bg) !important;
+}
+
+/* NAV BAR */
+
+.NavigationBar {
+    height: 41px !important;
+    padding: 4.5px 0px 0px 4.5px !important;
+    /*background-color: # !important;*/
+    margin-bottom: 5px;
+}
+
+.NavigationBar .panel-btn:hover {
+    border-radius: 3px !important;
+    background-color: var(--tabs-bg-hover) !important;
+}
+
+.NavigationBar .panel-btn[data-active="true"] {
+    border-radius: 3px !important;
+    background-color: var(--bg) !important;
+}
+
+.NavigationBar .panel-btn[data-active="true"]:hover {
+    border-radius: 3px !important;
+    background-color: var(--tabs-bg-hover) !important;
+}
+
+.NavigationBar .panel-btn>svg,
+.NavigationBar .panel-btn>img {
+    fill: var(--panel-btn) !important;
+}
+
+/* SIDEBAR HACK PATCHES */
+
+@media (max-width: 50px) {
+
+    /* Show first if there are notifications available */
+    .PinnedTabsBar .tab-wrapper:has(.Tab[data-updated="true"]) {
+        order: -2 !important;
+    }
+
+    .PinnedTabsBar .tab-wrapper:has(.Tab[data-active="true"]) {
+        order: -1 !important;
+    }
+
+    /* Fix to tab tree identation when minimised */
+    #root:not(:hover) .Tab {
+        --tabs-indent: 0px;
+    }
+
+    .Tab[data-lvl]>div.lvl-wrapper {
+        right: -2px;
+    }
+
+    .Tab {
+        max-width: 34px;
+    }
+
+    .Tab .fav {
+        z-index: 1;
+    }
+
+    .Tab .audio {
+        z-index: 1;
+        margin-left: -12px;
+        height: 26px;
+    }
+
+    .Tab .title {
+        display: none;
+    }
+
+    .NavigationBar .settings-btn {
+        display: none;
+    }
+}
+
+/* OPTIONAL */
+
+/* Disable these two snippets below to make pinned tabs wrap when minimized */
+.PinnedTabsBar {
+    flex-wrap: nowrap !important;
+}
+
+.PinnedTabsBar .Tab {
+    overflow: hidden !important;
+    min-width: var(--tabs-pinned-width) !important;
+}
+
+/* Optional patch for better tab notifications on pinned tabs */
+
+.PinnedTabsBar .Tab[data-audible] .fav>img,
+.PinnedTabsBar .Tab[data-muted] .fav>img,
+.PinnedTabsBar .Tab[data-loading] .fav>img,
+.PinnedTabsBar .Tab .fav>img {
+    mask: none;
+}
+
+.PinnedTabsBar .Tab[data-updated="true"] .fav>img {
+    mask: radial-gradient(circle at calc(100% - 2px) calc(100% - 2px), rgba(0, 0, 0, 0.141), rgba(0, 0, 0, 0.141) 4px, #000 5px, #000);
+}
+
+.PinnedTabsBar .Tab .audio-badge {
+    top: 5px;
+}
+
+.PinnedTabsBar .Tab .update-badge {
+    opacity: 0;
+}
+
+.PinnedTabsBar .Tab[data-updated="true"] .update-badge {
+    opacity: 100;
+}
+
+.Tab .title {
+    transition: margin-left 300ms ease;
+}
+
+.Tab:hover {
+    --tabs-inner-gap: 8px;
+}
+
+.Tab:hover .title {
+    margin-left: 8px;
+}
+
+.Tab[data-discarded="true"] .title {
+    opacity: 80%;
+}

--- a/theme/function-sidebery-autohide.css
+++ b/theme/function-sidebery-autohide.css
@@ -1,0 +1,91 @@
+/* ----------------------------------------------------------
+- Autohide Sidebery sidebar extension
+- this function is enabled by the tabs.sidebery.autohide setting in about:config
+- it will not affect other sidebars (history, favorites, notes, sideview, etc.)
+-----------------------------------------------------------*/
+
+@media (-moz-bool-pref: "ultima.sidebery.autohide") {
+    :root {
+        --bg: #1a1b26;
+    }
+
+    /* hides the sidebar header */
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"] #sidebar-header {
+        display: none !important;
+    }
+
+    /* autohide */
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"] {
+        --uc-sidebar-width: 37px;
+        --uc-sidebar-hover-width: 320px;
+        --uc-autohide-sidebar-delay: 4ms;
+        /* Waiting time before hiding sidebar */
+        position: relative;
+        min-width: var(--uc-sidebar-width) !important;
+        width: var(--uc-sidebar-width) !important;
+        max-width: var(--uc-sidebar-width) !important;
+        z-index: 100;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"][positionend] {
+        direction: rtl;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"][positionend]>* {
+        direction: ltr;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"][positionend]:-moz-locale-dir(rtl) {
+        direction: ltr;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"][positionend]:-moz-locale-dir(rtl)>* {
+        direction: rtl;
+    }
+
+    /* HIDE SIDE BAR IN FULL SCREEN */
+    #main-window[titlepreface*="[S] "][inFullscreen="true"] #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"] {
+        --uc-sidebar-width: 0px;
+    }
+
+    #sidebar-splitter {
+        display: none;
+    }
+
+    #sidebar-header {
+        overflow: hidden;
+    }
+
+    #sidebar {
+        transition: min-width 115ms linear var(--uc-autohide-sidebar-delay) !important;
+        min-width: var(--uc-sidebar-width) !important;
+        will-change: min-width;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"]:hover>#sidebar {
+        min-width: var(--uc-sidebar-hover-width) !important;
+        transition-delay: 0ms !important;
+    }
+
+    .sidebar-panel {
+        background-color: transparent !important;
+    }
+
+    .sidebar-panel #search-box {
+        -moz-appearance: none !important;
+        background-color: rgba(249, 249, 250, 0.1) !important;
+        color: inherit !important;
+    }
+
+    /* Move statuspanel to the other side when sidebar is hovered so it doesn't get covered by sidebar */
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"]:not([positionend]):hover~#appcontent #statuspanel {
+        inset-inline: auto 0px !important;
+    }
+
+    #sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"]:not([positionend]):hover~#appcontent #statuspanel-label {
+        margin-inline: 0px !important;
+        border-left-style: solid !important;
+    }
+
+}

--- a/user.js
+++ b/user.js
@@ -9,6 +9,7 @@ user_pref("ultima.tabs.vertical.onlyprivate", false);
 
 /*sidebar*/
 user_pref("ultima.sidebar.autohide", false);
+user_pref("ultima.sidebery.autohide", false);
 
 /*extension theme on-off*/
 user_pref("ultima.theme.extensions", true);
@@ -38,3 +39,4 @@ user_pref("ultima.OS.kdedecorations", false);
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 user_pref("svg.context-properties.content.enabled", true);
 user_pref("toolkit.tabbox.switchByScrolling", true);
+

--- a/userChrome.css
+++ b/userChrome.css
@@ -21,6 +21,7 @@ Come to the modification page: https://github.com/soulhotel/FF-ULTIMA/blob/main/
 @import url(theme/function-mini-button-bar.css);
 @import url(theme/function-tabs-collapse.css);
 @import url(theme/function-sidebar-autohide.css);
+@import url(theme/function-sidebery-autohide.css);
 @import url(theme/function-containers-indicator.css);
 @import url(theme/function-menu-button.css);
 @import url(theme/function-privatemode-indicator.css); /* sourced from MOG */


### PR DESCRIPTION
Added support for the flag `ultima.sidebery.autohide`, which allows changes to Sidebery only, including autohide and removing the close button and title section. While keeping the buttons and titles on alternative sidebars (bookmarks, favorites, notes, sideview, etc).
[Screencast_20240626_013055.webm](https://github.com/soulhotel/FF-ULTIMA/assets/23535289/c6140b4c-7331-4c15-be0a-41af08037d5d)

I've also dropped in the Sidebery theme that I use (doc/sidebery-alt-dark.css), the only thing worth noting here is that I went for a wrap mode on the pinned tabs, that shows the first pinned tab by default when hidden, unless another pinned tab is active or has a notification pending, in which case these are displayed instead (lines 87 and 91)