### PR TITLE
adds fullscreen support to overlay sidebar

### DIFF
--- a/theme/all-global-positioning.css
+++ b/theme/all-global-positioning.css
@@ -434,8 +434,10 @@ still should be way easier than the original verttab hack just gotta wait*/
     z-index:997 !important;
 }
 
+#main-window:not([inDOMFullscreen="true"]) {
 #browser {
-margin-left:50px !important;
+        margin-left:50px !important;
+    }
 }
 
 #sidebar-main:has([expanded=""]):not(:hover){ width: 50px !important;}

--- a/theme/all-global-positioning.css
+++ b/theme/all-global-positioning.css
@@ -434,7 +434,7 @@ still should be way easier than the original verttab hack just gotta wait*/
     z-index:997 !important;
 }
 
-#main-window:not([inDOMFullscreen="true"]) {
+#main-window:not([inDOMFullscreen]) {
 #browser {
         margin-left:50px !important;
     }


### PR DESCRIPTION
I have been using this theme, it's pretty awesome! Thanks for your hard work.

I wanted to try the "Autohide implementation 3 - overlay content" since this style works better for me. And it worked pretty great! However, when going into super-full-screen mode, like watching movies, this margin caused a "empty sidebar" to overlay the video :( 
I saw you already take advantage of this flag, `inDOMFullscreen`, in other places, and that you know what you're doing and that this is just a 'testing' style, this is just a headsup then about this use-case when it comes time to bake this feature in :) 

Thanks again for working on this! And with this tweak, this theme is my daily driver!