### PR TITLE
Fix visibility issue on Catppuccin Mocha theme

### DIFF
--- a/theme/all-global-theme-catppuccin-mocha.css
+++ b/theme/all-global-theme-catppuccin-mocha.css
@@ -34,7 +34,7 @@ Custom Icons
     --uc-button-selected: rgb(17,17,27);
     --uc-tab-selected-bg: rgb(17,17,27);
     --uc-urlbar-background: rgb(24, 24, 37);
-    --uc-panel-background: rgb(17, 17, 27);
+    --uc-panel-background: rgb(24, 24, 37);
     --uc-panel-border: rgba(27, 25, 35, 1);
     --uc-panel-border-ii: rgba(70, 70, 80, 0.2);
     --uc-context-menu: rgb(49, 50, 68);

--- a/theme/all-global-theme-catppuccin-mocha.css
+++ b/theme/all-global-theme-catppuccin-mocha.css
@@ -31,7 +31,7 @@ Custom Icons
     --uc-background-main: rgb(24, 24, 37);
     --uc-background-layered: rgb(17, 17, 27);
     --uc-transparent: rgba(0,0,0,0);
-    --uc-button-selected: rgb(24, 24, 37);
+    --uc-button-selected: rgb(17,17,27);
     --uc-tab-selected-bg: rgb(17,17,27);
     --uc-urlbar-background: rgb(24, 24, 37);
     --uc-panel-background: rgb(17, 17, 27);


### PR DESCRIPTION
Selected URL and background for the url bar list were the same colour which made it difficult to tell which url is selected

Current visibility:
![1](https://github.com/user-attachments/assets/d7a94414-c411-4e85-9cfb-a7a1ff4c4879)
Patched:
![2](https://github.com/user-attachments/assets/c4ae49b3-c099-4c43-9f1d-70fd3b8235bc)
