### PR TITLE
Little Color scheme creation tutorial link fix

### DIFF
--- a/theme/all-color-schemes-wallpapers.css
+++ b/theme/all-color-schemes-wallpapers.css
@@ -3,7 +3,7 @@
   
 /*
 This file handles New Tab Backgrounds for Color Schemes.
-Create Your Own - TUTORIAL: https://github.com/soulhotel/FF-ULTIMA/blob/main/doc/new-color-scheme.md
+Create Your Own - TUTORIAL: https://github.com/soulhotel/FF-ULTIMA/wiki/Create-a-Color-Scheme
 
 Use the template below to enter your theme into the list:
 


### PR DESCRIPTION
Hi! Just started using the theme. I'm Loving it! :)

I noticed a tutorial link inside `theme/all-color-schemes-wallpapers.css` that was taking to a not found page. I replaced it with what I'm assuming is the updated one.

Don't really know your rules about PRs, but I hope this helps.