### PR TITLE
Add option to override scrollbar-width to thin

### DIFF
--- a/theme/website-styles.css
+++ b/theme/website-styles.css
@@ -16,6 +16,15 @@ bing declutter
     scrollbar-color: rgba(110, 110, 110, 0.3) rgba(255,255,255, 0) !important;
 }
 
+@media -moz-pref("ultima.scrollbar.thin") {
+    :root {
+        scrollbar-width: thin !important;
+    }
+    * {
+        scrollbar-width: thin !important;
+    }
+}
+
 /* PIP button */
 .pip-wrapper {transform: scale(0.6);}
 
@@ -36,6 +45,3 @@ bing declutter
     }
 
 }
-
-
-

--- a/user.js
+++ b/user.js
@@ -3,10 +3,10 @@
 ┏┓┏┓  ┳┳┓ ┏┳┓┳┳┳┓┏┓
 ┣ ┣   ┃┃┃  ┃ ┃┃┃┃┣┫
 ┻ ┻   ┗┛┗┛ ┻ ┻┛ ┗┛┗
-                   
+
 FF Ultima:         https://github.com/soulhotel/FF-ULTIMA
 Wiki:              https://github.com/soulhotel/FF-ULTIMA/wiki/Settings
-Latest Version:    https://github.com/soulhotel/FF-ULTIMA/releases/latest                 
+Latest Version:    https://github.com/soulhotel/FF-ULTIMA/releases/latest
 License:           https://github.com/soulhotel/FF-ULTIMA/blob/main/LICENSE MPL 2.0
 
 \////////////////////////////////////////////////////////////////////////////////////////*/
@@ -118,6 +118,7 @@ user_pref("ultima.theme.icons", true);
 user_pref("user.theme.xtension.ublock", true);
 user_pref("user.theme.xtension.YT", false);
 user_pref("user.theme.xtension.reddit", false);
+user_pref("ultima.scrollbar.thin", false);
 /*user_pref("ultima.theme.menubar", true); mark for removal */
 user_pref("user.theme.xtension.swap.addon.colors", true);
 user_pref("user.theme.xtras.tab.outline.color", "gradient");
@@ -181,7 +182,5 @@ user_pref("general.smoothScroll", true);
 user_pref("general.smoothScroll.msdPhysics.enabled", true);
 
 /* extra privacy */
-user_pref("browser.send_pings", false); 
+user_pref("browser.send_pings", false);
 user_pref("extensions.pocket.enabled", false);
-
-


### PR DESCRIPTION
#### The issue:
On Windows, the default scrollbar is pretty thick, and the current version of the theme forces it to auto.
Before using FF-ULTIMA, I had a custom CSS that actually forced it to be thinner, but it's not working anymore without modifying the theme.

I used a modified version for some time and didn't notice any issues, so I decided to make it configurable and share it with the public. I think that thin scrollbars look much cleaner, and other people may also like that.
However, I understand that there was a reason for scrollbar-width: auto !important; to be added, and I may not have the use case where that was critical, so that PR is more like a feature request.

#### Here is how it looks on Windows 10:

Before:
<img width="2223" height="1380" alt="image" src="https://github.com/user-attachments/assets/a898972e-198e-42c7-9e78-f353ba0c56f6" />
After:
<img width="2223" height="1380" alt="image" src="https://github.com/user-attachments/assets/9e16f87a-8453-4cc5-a8b5-aa166934b48b" />

p.s.
I didn't find any contribution guide or rules, so i just did my best to describe the issue.